### PR TITLE
Añadido CLI para enviar reportes de la bitácora

### DIFF
--- a/cli/commands/cmd_bitacoras.py
+++ b/cli/commands/cmd_bitacoras.py
@@ -1,0 +1,36 @@
+"""
+CLI Bitácoras
+"""
+
+import sys
+
+import click
+
+from orion.blueprints.bitacoras.tasks import enviar_reporte_diario
+from lib.exceptions import MyAnyError
+
+
+@click.group()
+def cli():
+    """Bitácoras"""
+
+
+@click.command()
+@click.argument("modulo_nombre", type=str)
+@click.argument("to_email", type=str)
+def enviar(modulo_nombre, to_email):
+    """Enviar mensaje con el reporte diario del módulo dado"""
+    click.echo(f"Inicia el envío del mensaje con el reporte diario del módulo {modulo_nombre} a {to_email}")
+
+    # Enviar el mensaje
+    try:
+        mensaje_termino = enviar_reporte_diario(modulo_nombre, to_email)
+    except MyAnyError as error:
+        click.echo(error)
+        sys.exit(1)
+
+    # Mensaje de termino
+    click.echo(mensaje_termino)
+
+
+cli.add_command(enviar)

--- a/orion/blueprints/bitacoras/tasks.py
+++ b/orion/blueprints/bitacoras/tasks.py
@@ -1,0 +1,124 @@
+"""
+Bitácoras, tareas para ejecutar en el fondo
+"""
+
+import logging
+import os
+from datetime import datetime, timedelta
+
+import pytz
+import sendgrid
+from dotenv import load_dotenv
+from sendgrid.helpers.mail import Content, Email, Mail, To
+
+from orion.app import create_app
+from orion.blueprints.bitacoras.models import Bitacora
+from orion.blueprints.modulos.models import Modulo
+from orion.extensions import database
+from lib.exceptions import MyAnyError, MyNotExistsError, MyNotValidParamError
+from lib.tasks import set_task_error, set_task_progress
+
+# Constantes
+TIMEZONE = "America/Mexico_City"
+
+# Bitácora logs/bitacoras.log
+logs = logging.getLogger(__name__)
+logs.setLevel(logging.INFO)
+formato = logging.Formatter("%(asctime)s:%(levelname)s:%(message)s")
+empunadura = logging.FileHandler("logs/bitacoras.log")
+empunadura.setFormatter(formato)
+logs.addHandler(empunadura)
+
+# Cargar variables de entorno
+load_dotenv()
+HOST = os.getenv("HOST", "http://localhost:5000")
+SENDGRID_API_KEY = os.getenv("SENDGRID_API_KEY", "")
+SENDGRID_FROM_EMAIL = os.getenv("SENDGRID_FROM_EMAIL", "plataforma.web@pjecz.gob.mx")
+
+# Cargar la aplicación para tener acceso a la base de datos
+app = create_app()
+app.app_context().push()
+database.app = app
+
+
+def enviar_reporte_diario(modulo_nombre: str, to_email: str) -> str:
+    """Enviar mensaje con el reporte diario del módulo dado"""
+
+    # Agregar mensaje de inicio
+    mensaje = f"Inicia el envío del mensaje con reporte diario del módulo {modulo_nombre} a {to_email}"
+    logs.info(mensaje)
+
+    # Consultar y validar el módulo
+    modulo = Modulo.query.filter(Modulo.nombre == modulo_nombre).first()
+    if not modulo:
+        mensaje = f"El módulo {modulo_nombre} no existe"
+        logs.error(mensaje)
+        raise MyNotExistsError(mensaje)
+    if modulo.estatus != "A":
+        mensaje = f"El módulo {modulo_nombre} no está activo"
+        logs.error(mensaje)
+        raise MyNotValidParamError(mensaje)
+
+    # Definir el tiempo para filtrar a partir de las últimas 24 horas
+    desde_dt = datetime.now() - timedelta(hours=24)
+
+    # Consultar la bitácora filtrando por el módulo y las últimas 24 horas
+    bitacoras = (
+        Bitacora.query.filter(Bitacora.creado >= desde_dt)
+        .filter(Bitacora.modulo_id == modulo.id)
+        .filter(Bitacora.estatus == "A")
+        .order_by(Bitacora.creado.desc())
+        .all()
+    )
+
+    # Elaborar el asunto del mensaje
+    asunto_str = f"PJECZ Plataforma Web: Bitácora diaria de {modulo_nombre}"
+
+    # Elaborar el contenido del mensaje
+    fecha_elaboracion = datetime.now(tz=pytz.timezone(TIMEZONE)).strftime("%d/%b/%Y %H:%M")
+    contenidos = []
+    contenidos.append(f"<h2>{asunto_str}</h2>")
+    contenidos.append(f"<p>Elaborado el {fecha_elaboracion}</p>")
+    if not bitacoras:
+        mensaje = f"No hay bitácoras del módulo {modulo_nombre} en las últimas 24 horas"
+        logs.info(mensaje)
+        contenidos.append(mensaje)
+    else:
+        contenidos.append("<ul>")
+        for bitacora in bitacoras:
+            contenidos.append(f"<li>{bitacora.usuario.nombre} - {bitacora.descripcion}</li>")
+        contenidos.append("</ul>")
+        logs.info(f"Se encontraron {len(bitacoras)} bitácoras del módulo {modulo_nombre} en las últimas 24 horas")
+    contenido_html = "\n".join(contenidos)
+
+    # Enviar el e-mail
+    send_grid = sendgrid.SendGridAPIClient(api_key=SENDGRID_API_KEY)
+    remitente_email = Email(SENDGRID_FROM_EMAIL)
+    destinatario_email = To(to_email)
+    contenido = Content("text/html", contenido_html)
+    mail = Mail(remitente_email, destinatario_email, asunto_str, contenido)
+    send_grid.client.mail.send.post(request_body=mail.get())
+
+    # Entregar mensaje de término
+    mensaje = f"Mensaje enviado a {to_email} con {len(bitacoras)} bitácoras del módulo {modulo_nombre}"
+    logs.info(mensaje)
+    return mensaje
+
+
+def lanzar_enviar_reporte_diario(modulo_nombre: str, to_email: str) -> str:
+    """Lanzar la tarea de enviar el reporte diario del módulo dado"""
+
+    # Iniciar la tarea en el fondo
+    set_task_progress(0, f"Inicia tarea para enviar el reporte diario del módulo {modulo_nombre}")
+
+    # Ejecutar
+    try:
+        mensaje_termino = enviar_reporte_diario(modulo_nombre, to_email)
+    except MyAnyError as error:
+        mensaje_error = str(error)
+        set_task_error(mensaje_error)
+        return mensaje_error
+
+    # Terminar la tarea en el fondo y entregar el mensaje de término
+    set_task_progress(100, mensaje_termino)
+    return mensaje_termino

--- a/orion/blueprints/personas_adjuntos/views.py
+++ b/orion/blueprints/personas_adjuntos/views.py
@@ -157,7 +157,7 @@ def new_with_persona_id(persona_id):
                     bitacora = Bitacora(
                         modulo=Modulo.query.filter_by(nombre=MODULO).first(),
                         usuario=current_user,
-                        descripcion=safe_message(f"Editado Archivo Adjunto {adjunto.id}"),
+                        descripcion=safe_message(f"Editado Archivo Adjunto {adjunto.id} - {adjunto.persona.nombre_completo}"),
                         url=url_for("personas_adjuntos.detail", persona_adjunto_id=adjunto.id),
                     )
                     bitacora.save()
@@ -238,7 +238,9 @@ def edit(persona_adjunto_id):
                     bitacora = Bitacora(
                         modulo=Modulo.query.filter_by(nombre=MODULO).first(),
                         usuario=current_user,
-                        descripcion=safe_message(f"Editado Archivo Adjunto {adjunto_new.id}, se dio de baja {adjunto.id}"),
+                        descripcion=safe_message(
+                            f"Editado Archivo Adjunto {adjunto_new.id}, se dio de baja {adjunto.id} - {adjunto.persona.nombre_completo}"
+                        ),
                         url=url_for("personas_adjuntos.detail", persona_adjunto_id=adjunto_new.id),
                     )
                     bitacora.save()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,6 +39,7 @@ unidecode = "^1.3.8"
 uvicorn = "^0.34.0"
 werkzeug = "^3.1.2"
 wtforms = "^3.2.1"
+sendgrid = "^6.12.0"
 
 
 [tool.poetry.group.dev.dependencies]


### PR DESCRIPTION
Se necesita:
  - Instalar en Poetry el paquete de __sendgrid__: `poetry add sendgird`
  - Añadir las variables de entorno:
```bash
# Sendgrid
SENDGRID_API_KEY=
SENDGRID_FROM_EMAIL=
SENDGRID_TO_EMAIL_REPORTES=
```